### PR TITLE
add ping [message] support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Therefore, I opened this repository and started to support some useful commands 
 ### 新增已支持命令 NEW SUPPORTED COMMANDS
 - [script](https://redis.io/commands/script-load/) :script load/script exists/script flush
 - [scan](https://redis.io/commands/scan/)
+- [ping](https://redis.io/commands/ping/): ping [message]


### PR DESCRIPTION
Problem

redis `ping [message]` command not support.

Result

```
127.0.0.1:60100> ping
PONG
127.0.0.1:60100> ping nice
"nice"
```
